### PR TITLE
Improved targeting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ subprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings loom.officialMojangMappings()
+
+        modCompileOnly "me.shedaniel:REIPluginCompatibilities-forge-annotations:9+"
     }
 }
 

--- a/common/src/main/java/net/impleri/itemskills/InventoryHelper.java
+++ b/common/src/main/java/net/impleri/itemskills/InventoryHelper.java
@@ -1,0 +1,59 @@
+package net.impleri.itemskills;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+class InventoryHelper {
+    private static Predicate<ItemStack> shouldRemoveItem(Player player, boolean wearable) {
+        return (ItemStack stack) -> {
+            if (!stack.isEmpty()) {
+                var item = ItemHelper.getItem(stack);
+
+                var isHoldable = ItemHelper.isHoldable(player, item);
+
+                var isWearable = !wearable || ItemHelper.isWearable(player, item);
+
+                return !isHoldable || !isWearable;
+            }
+
+            return false;
+        };
+    }
+
+    public static List<ItemStack> getItemsToRemove(Player player, NonNullList<ItemStack> inventory) {
+        return inventory.stream()
+                .filter(shouldRemoveItem(player, false))
+                .toList();
+    }
+
+    private static void removeFromEquippedSlot(Player player, NonNullList<ItemStack> list, ItemStack stack, int index) {
+        ItemSkills.LOGGER.debug("{} should not have {} equipped", player.getName().getString(), ItemHelper.getItemKey(stack));
+
+        list.set(index, ItemStack.EMPTY);
+        player.getInventory().placeItemBackInInventory(stack);
+    }
+
+    public static void filterFromList(Player player, NonNullList<ItemStack> list) {
+        var predicate = shouldRemoveItem(player, true);
+
+        for (int i = 0; i < list.size(); ++i) {
+            var stack = list.get(i);
+            if (predicate.test(stack)) {
+                removeFromEquippedSlot(player, list, stack, i);
+            }
+        }
+    }
+
+    public static Consumer<ItemStack> dropFromInventory(Player player) {
+        return (ItemStack stack) -> {
+            ItemSkills.LOGGER.debug("{} should not be holding {}", player.getName().getString(), ItemHelper.getItemKey(stack));
+            player.getInventory().removeItem(stack);
+            player.drop(stack, true);
+        };
+    }
+}

--- a/common/src/main/java/net/impleri/itemskills/ItemEvents.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemEvents.java
@@ -20,36 +20,21 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.List;
 
 class ItemEvents {
     public void registerEventHandlers() {
-        // holdable
-        PlayerEvent.PICKUP_ITEM_PRE.register(this::beforePlayerPickup);
-
-        // holdable AND wearable
         TickEvent.PLAYER_POST.register(this::onPlayerTick);
 
-        // harmful
-        EntityEvent.LIVING_HURT.register(this::beforePlayerAttack);
+        PlayerEvent.PICKUP_ITEM_PRE.register(this::beforePlayerPickup);
 
-        // usable
-        BlockEvent.BREAK.register(this::beforeMine);
         InteractionEvent.LEFT_CLICK_BLOCK.register(this::beforeUseItemBlock);
         InteractionEvent.RIGHT_CLICK_BLOCK.register(this::beforeUseItemBlock);
         InteractionEvent.RIGHT_CLICK_ITEM.register(this::beforeUseItem);
         InteractionEvent.INTERACT_ENTITY.register(this::beforeInteractEntity);
-    }
 
-    private EventResult beforePlayerPickup(Player player, ItemEntity entity, ItemStack stack) {
-        var item = ItemHelper.getItemKey(stack);
-        ItemSkills.LOGGER.debug("{} is about to pickup {}", player.getName().getString(), item);
-
-        if (Restrictions.INSTANCE.isHoldable(player, item)) {
-            return EventResult.pass();
-        }
-
-        return EventResult.interruptFalse();
+        EntityEvent.LIVING_HURT.register(this::beforePlayerAttack);
+        BlockEvent.BREAK.register(this::beforeMine);
     }
 
     private void onPlayerTick(Player player) {
@@ -60,95 +45,91 @@ class ItemEvents {
         Inventory inventory = player.getInventory();
 
         // Move unwearable items from armor and offhand into normal inventory
-        ItemHelper.isListWearable(player, inventory.armor);
-        ItemHelper.isListWearable(player, inventory.offhand);
-        ItemHelper.isListHoldable(player, inventory.offhand);
+        InventoryHelper.filterFromList(player, inventory.armor);
+        InventoryHelper.filterFromList(player, inventory.offhand);
 
-        // Drop unholdable items from inventory
-        ArrayList<ItemStack> itemsToRemove = new ArrayList<>();
-        inventory.items.forEach(stack -> {
-            var item = ItemHelper.getItemKey(stack);
-            if (item.equals(ItemHelper.defaultItem)) {
-                return;
-            }
+        // Get unholdable items from inventory
+        List<ItemStack> itemsToRemove = InventoryHelper.getItemsToRemove(player, inventory.items);
 
-            if (!Restrictions.INSTANCE.isHoldable(player, item)) {
-                ItemSkills.LOGGER.debug("{} should not be holding {}", player.getName().getString(), item);
-                itemsToRemove.add(stack);
-            }
-        });
+        // Drop the unholdable items from the normal inventory
+        if (!itemsToRemove.isEmpty()) {
+            ItemSkills.LOGGER.debug("{} is holding {} item(s) that should be dropped", player.getName().getString(), itemsToRemove.size());
+            itemsToRemove.forEach(InventoryHelper.dropFromInventory(player));
+        }
+    }
 
-        itemsToRemove.forEach(stack -> {
-            ItemSkills.LOGGER.debug("Removing {} from {}'s inventory", ItemHelper.getItemKey(stack), player.getName().getString());
-            inventory.removeItem(stack);
-            player.drop(stack, true);
-        });
+    private EventResult beforePlayerPickup(Player player, ItemEntity entity, ItemStack stack) {
+        var item = ItemHelper.getItem(stack);
+
+        if (ItemHelper.isHoldable(player, item)) {
+            return EventResult.pass();
+        }
+
+        ItemSkills.LOGGER.debug("{} is about to pickup {}", player.getName().getString(), ItemHelper.getItemKey(item));
+
+        return EventResult.interruptFalse();
     }
 
     private EventResult beforePlayerAttack(LivingEntity entity, DamageSource source, float amount) {
         var attacker = source.getEntity();
-        if (attacker instanceof Player player) {
-            var weapon = ItemHelper.getItemKey(player.getMainHandItem());
 
-            ItemSkills.LOGGER.debug("{} is about to attack {} using {} for {} damage", player.getName().getString(), entity.getName().getString(), weapon, amount);
+        if (attacker instanceof Player player) {
+            var weapon = ItemHelper.getItem(player.getMainHandItem());
 
             if (Restrictions.INSTANCE.isHarmful(player, weapon)) {
-                return EventResult.pass();
-            }
+                ItemSkills.LOGGER.debug("{} was about to attack {} using {} for {} damage", player.getName().getString(), entity.getName().getString(), ItemHelper.getItemKey(weapon), amount);
 
-            return EventResult.interruptFalse();
+                return EventResult.interruptFalse();
+            }
         }
 
         return EventResult.pass();
     }
 
     private EventResult beforeMine(Level level, BlockPos pos, BlockState state, ServerPlayer player, @Nullable IntValue xp) {
-        var tool = ItemHelper.getItemKey(player.getMainHandItem());
-
-        ItemSkills.LOGGER.debug("{} is about to mine {} using {}", player.getName().getString(), tool, state.getBlock().getName().getString());
+        var tool = ItemHelper.getItem(player.getMainHandItem());
 
         if (Restrictions.INSTANCE.isUsable(player, tool)) {
             return EventResult.pass();
         }
+
+        ItemSkills.LOGGER.debug("{} was about to mine {} using {}", player.getName().getString(), ItemHelper.getItemKey(tool), state.getBlock().getName().getString());
 
         return EventResult.interruptFalse();
     }
 
     private EventResult beforeInteractEntity(Player player, Entity entity, InteractionHand hand) {
-        var itemUsed = ItemHelper.getItemUsed(player, hand);
-        var tool = ItemHelper.getItemKey(itemUsed);
-
-        ItemSkills.LOGGER.debug("{} is about to interact with entity {} using {}", player.getName().getString(), entity.getName().getString(), tool);
+        var tool = ItemHelper.getItemUsed(player, hand);
 
         if (Restrictions.INSTANCE.isUsable(player, tool)) {
             return EventResult.pass();
         }
+
+        ItemSkills.LOGGER.debug("{} was about to interact with entity {} using {}", player.getName().getString(), entity.getName().getString(), ItemHelper.getItemKey(tool));
 
         return EventResult.interruptFalse();
     }
 
     private CompoundEventResult<ItemStack> beforeUseItem(Player player, InteractionHand hand) {
-        var itemUsed = ItemHelper.getItemUsed(player, hand);
-        var tool = ItemHelper.getItemKey(itemUsed);
-
-        ItemSkills.LOGGER.debug("{} is about to use {}", player.getName().getString(), tool);
+        var tool = ItemHelper.getItemUsed(player, hand);
 
         if (Restrictions.INSTANCE.isUsable(player, tool)) {
             return CompoundEventResult.pass();
         }
 
+        ItemSkills.LOGGER.debug("{} is about to use {}", player.getName().getString(), ItemHelper.getItemKey(tool));
+
         return CompoundEventResult.interruptFalse(null);
     }
 
     private EventResult beforeUseItemBlock(Player player, InteractionHand hand, BlockPos pos, Direction face) {
-        var itemUsed = ItemHelper.getItemUsed(player, hand);
-        var tool = ItemHelper.getItemKey(itemUsed);
-
-        ItemSkills.LOGGER.debug("{} is about to interact with block {} using {}", player.getName().getString(), player.level.getBlockState(pos).getBlock().getName().getString(), tool);
+        var tool = ItemHelper.getItemUsed(player, hand);
 
         if (Restrictions.INSTANCE.isUsable(player, tool)) {
             return EventResult.pass();
         }
+
+        ItemSkills.LOGGER.debug("{} is about to interact with block {} using {}", player.getName().getString(), player.level.getBlockState(pos).getBlock().getName().getString(), ItemHelper.getItemKey(tool));
 
         return EventResult.interruptFalse();
     }

--- a/common/src/main/java/net/impleri/itemskills/ItemEvents.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemEvents.java
@@ -3,10 +3,12 @@ package net.impleri.itemskills;
 import dev.architectury.event.CompoundEventResult;
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.common.*;
+import dev.architectury.platform.Platform;
 import dev.architectury.utils.value.IntValue;
 import net.impleri.itemskills.api.Restrictions;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
@@ -24,6 +26,7 @@ import java.util.List;
 
 class ItemEvents {
     public void registerEventHandlers() {
+        LifecycleEvent.SERVER_STARTING.register(this::onStartup);
         TickEvent.PLAYER_POST.register(this::onPlayerTick);
 
         PlayerEvent.PICKUP_ITEM_PRE.register(this::beforePlayerPickup);
@@ -35,6 +38,12 @@ class ItemEvents {
 
         EntityEvent.LIVING_HURT.register(this::beforePlayerAttack);
         BlockEvent.BREAK.register(this::beforeMine);
+    }
+
+    private void onStartup(MinecraftServer minecraftServer) {
+        if (Platform.isModLoaded("kubejs")) {
+            net.impleri.itemskills.integrations.kubejs.ItemSkillsPlugin.onStartup();
+        }
     }
 
     private void onPlayerTick(Player player) {

--- a/common/src/main/java/net/impleri/itemskills/ItemHelper.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemHelper.java
@@ -1,15 +1,15 @@
 package net.impleri.itemskills;
 
 import net.impleri.itemskills.api.Restrictions;
-import net.minecraft.core.NonNullList;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-
-import java.util.function.Predicate;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Recipe;
 
 public class ItemHelper {
     public static ResourceLocation getItemKey(ItemStack stack) {
@@ -20,34 +20,58 @@ public class ItemHelper {
         return Registry.ITEM.getKey(item);
     }
 
-    public static final ResourceLocation defaultItem = getItemKey((Item) null);
-
-    public static ItemStack getItemUsed(Player player, InteractionHand hand) {
-        return (hand == InteractionHand.OFF_HAND) ? player.getOffhandItem() : player.getMainHandItem();
+    public static Item getItem(ResourceLocation resource) {
+        return Registry.ITEM.get(resource);
     }
 
-    public static void isListWearable(Player player, NonNullList<ItemStack> list) {
-        iterateList(list, player, (ResourceLocation item) -> Restrictions.INSTANCE.isWearable(player, item));
+    public static Item getItem(ItemStack stack) {
+        return stack.getItem();
     }
 
-    public static void isListHoldable(Player player, NonNullList<ItemStack> list) {
-        iterateList(list, player, (ResourceLocation item) -> Restrictions.INSTANCE.isHoldable(player, item));
+    public static Item getItem(ItemEntity entity) {
+        return getItem(entity.getItem());
     }
 
-    private static void iterateList(NonNullList<ItemStack> list, Player player, Predicate<ResourceLocation> isItemAllowed) {
-        int i;
-        for (i = 0; i < list.size(); ++i) {
-            var stack = list.get(i);
-            var item = getItemKey(stack);
-            if (item.equals(defaultItem)) {
-                return;
-            }
+    public static ItemStack getItemStack(ResourceLocation resource) {
+        var item = getItem(resource);
 
-            if (!isItemAllowed.test(item)) {
-                ItemSkills.LOGGER.debug("{} should not be holding {}", player.getName().getString(), item);
-                list.set(i, ItemStack.EMPTY);
-                player.getInventory().placeItemBackInInventory(stack);
-            }
-        }
+        return new ItemStack(item);
+    }
+
+    public static boolean isEmptyItem(Item item) {
+        return (item == null || item == Items.AIR);
+    }
+
+    public static Item getItemUsed(Player player, InteractionHand hand) {
+        var item = (hand == InteractionHand.OFF_HAND) ? player.getOffhandItem() : player.getMainHandItem();
+
+        return getItem(item);
+    }
+
+    public static boolean isHoldable(Player player, Item item) {
+        return Restrictions.INSTANCE.isHoldable(player, item);
+    }
+
+    public static boolean isWearable(Player player, Item item) {
+        return Restrictions.INSTANCE.isWearable(player, item);
+    }
+
+    public static boolean isProducible(Player player, Item item) {
+        return Restrictions.INSTANCE.isProducible(player, item);
+    }
+
+    public static boolean isConsumable(Player player, Item item) {
+        return Restrictions.INSTANCE.isConsumable(player, item);
+    }
+
+    public static boolean isIdentifiable(Player player, Item item) {
+        return Restrictions.INSTANCE.isIdentifiable(player, item);
+    }
+
+    public static boolean isProducible(Player player, Recipe<?> recipe) {
+        var item = recipe.getResultItem().getItem();
+        ItemSkills.LOGGER.debug("Checking if {} is producible", item);
+
+        return isProducible(player, item);
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/ItemSkills.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemSkills.java
@@ -10,6 +10,7 @@ public class ItemSkills {
 
     public static void init() {
         LOGGER.info("Loaded Item Skills");
+        LOGGER.enableDebug();
         INSTANCE.registerEventHandlers();
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/ItemSkills.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemSkills.java
@@ -10,7 +10,6 @@ public class ItemSkills {
 
     public static void init() {
         LOGGER.info("Loaded Item Skills");
-        LOGGER.enableDebug();
         INSTANCE.registerEventHandlers();
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/api/Restrictions.java
+++ b/common/src/main/java/net/impleri/itemskills/api/Restrictions.java
@@ -1,14 +1,17 @@
 package net.impleri.itemskills.api;
 
+import net.impleri.itemskills.ItemHelper;
 import net.impleri.itemskills.restrictions.Registry;
 import net.impleri.itemskills.restrictions.Restriction;
 import net.impleri.playerskills.api.RestrictionsApi;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 
 import java.lang.reflect.Field;
+import java.util.function.Predicate;
 
-public class Restrictions extends RestrictionsApi<ResourceLocation, Restriction> {
+public class Restrictions extends RestrictionsApi<Item, Restriction> {
     private static final Field[] allRestrictionFields = Restriction.class.getDeclaredFields();
 
     public static final Restrictions INSTANCE = new Restrictions(Registry.INSTANCE, allRestrictionFields);
@@ -17,31 +20,41 @@ public class Restrictions extends RestrictionsApi<ResourceLocation, Restriction>
         super(registry, fields);
     }
 
-    public boolean isProducible(Player player, ResourceLocation item) {
+    @Override
+    protected ResourceLocation getTargetName(Item target) {
+        return ItemHelper.getItemKey(target);
+    }
+
+    @Override
+    protected Predicate<Item> createPredicateFor(Item item) {
+        return (Item target) -> target == item;
+    }
+
+    public boolean isProducible(Player player, Item item) {
         return canPlayer(player, item, "producible");
     }
 
-    public boolean isConsumable(Player player, ResourceLocation item) {
+    public boolean isConsumable(Player player, Item item) {
         return canPlayer(player, item, "consumable");
     }
 
-    public boolean isHoldable(Player player, ResourceLocation item) {
+    public boolean isHoldable(Player player, Item item) {
         return canPlayer(player, item, "holdable");
     }
 
-    public boolean isIdentifiable(Player player, ResourceLocation item) {
+    public boolean isIdentifiable(Player player, Item item) {
         return canPlayer(player, item, "identifiable");
     }
 
-    public boolean isHarmful(Player player, ResourceLocation item) {
+    public boolean isHarmful(Player player, Item item) {
         return canPlayer(player, item, "harmful");
     }
 
-    public boolean isWearable(Player player, ResourceLocation item) {
+    public boolean isWearable(Player player, Item item) {
         return canPlayer(player, item, "wearable");
     }
 
-    public boolean isUsable(Player player, ResourceLocation item) {
+    public boolean isUsable(Player player, Item item) {
         return canPlayer(player, item, "usable");
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/client/ClientApi.java
+++ b/common/src/main/java/net/impleri/itemskills/client/ClientApi.java
@@ -5,58 +5,58 @@ import net.impleri.itemskills.restrictions.Registry;
 import net.impleri.itemskills.restrictions.Restriction;
 import net.impleri.playerskills.api.RestrictionsApi;
 import net.impleri.playerskills.client.RestrictionsClient;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import java.util.List;
 
-public class ClientApi extends RestrictionsClient<ResourceLocation, Restriction> {
+public class ClientApi extends RestrictionsClient<Item, Restriction> {
     public static final ClientApi INSTANCE = new ClientApi(Registry.INSTANCE, Restrictions.INSTANCE);
 
-    private ClientApi(net.impleri.playerskills.restrictions.Registry<Restriction> registry, RestrictionsApi<ResourceLocation, Restriction> serverApi) {
+    private ClientApi(net.impleri.playerskills.restrictions.Registry<Restriction> registry, RestrictionsApi<Item, Restriction> serverApi) {
         super(registry, serverApi);
     }
 
-    private List<ResourceLocation> pluckTarget(List<Restriction> list) {
+    private List<Item> pluckTarget(List<Restriction> list) {
         return list.stream().map(r -> r.target).toList();
     }
 
-    public List<ResourceLocation> getHidden() {
+    public List<Item> getHidden() {
         return pluckTarget(getFiltered(r -> !r.producible && !r.consumable));
     }
 
-    public List<ResourceLocation> getUnproducible() {
+    public List<Item> getUnproducible() {
         return pluckTarget(getFiltered(r -> !r.producible));
     }
 
-    public List<ResourceLocation> getUnconsumable() {
+    public List<Item> getUnconsumable() {
         return pluckTarget(getFiltered(r -> !r.consumable));
     }
 
-    public boolean isProducible(ResourceLocation item) {
+    public boolean isProducible(Item item) {
         return canPlayer(item, "producible");
     }
 
-    public boolean isConsumable(ResourceLocation item) {
+    public boolean isConsumable(Item item) {
         return canPlayer(item, "consumable");
     }
 
-    public boolean isHoldable(ResourceLocation item) {
+    public boolean isHoldable(Item item) {
         return canPlayer(item, "holdable");
     }
 
-    public boolean isIdentifiable(ResourceLocation item) {
+    public boolean isIdentifiable(Item item) {
         return canPlayer(item, "identifiable");
     }
 
-    public boolean isHarmful(ResourceLocation item) {
+    public boolean isHarmful(Item item) {
         return canPlayer(item, "harmful");
     }
 
-    public boolean isWearable(ResourceLocation item) {
+    public boolean isWearable(Item item) {
         return canPlayer(item, "wearable");
     }
 
-    public boolean isUsable(ResourceLocation item) {
+    public boolean isUsable(Item item) {
         return canPlayer(item, "usable");
     }
 

--- a/common/src/main/java/net/impleri/itemskills/client/ItemSkillsClient.java
+++ b/common/src/main/java/net/impleri/itemskills/client/ItemSkillsClient.java
@@ -24,7 +24,7 @@ public class ItemSkillsClient {
     }
 
     private void beforeRenderItemTooltip(ItemStack stack, List<Component> lines, TooltipFlag flag) {
-        var item = ItemHelper.getItemKey(stack);
+        var item = ItemHelper.getItem(stack);
         if (!ClientApi.INSTANCE.isIdentifiable(item)) {
             ItemSkills.LOGGER.debug("Replacing tooltip for {}", item);
             lines.clear();

--- a/common/src/main/java/net/impleri/itemskills/integrations/jei/ItemSkillsJeiPlugin.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/jei/ItemSkillsJeiPlugin.java
@@ -1,5 +1,6 @@
 package net.impleri.itemskills.integrations.jei;
 
+import me.shedaniel.rei.plugincompatibilities.api.REIPluginCompatIgnore;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.recipe.IFocus;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@REIPluginCompatIgnore()
 public class ItemSkillsJeiPlugin implements IModPlugin {
     private IJeiRuntime runtime;
     private final List<Item> currentUnconsumables = new ArrayList<>();

--- a/common/src/main/java/net/impleri/itemskills/integrations/kubejs/ItemSkillsPlugin.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/kubejs/ItemSkillsPlugin.java
@@ -11,13 +11,8 @@ public class ItemSkillsPlugin extends KubeJSPlugin {
         EventsBinding.GROUP.register();
     }
 
-    @Override
-    public void initStartup() {
+    public static void onStartup() {
         Registry.INSTANCE.clear();
-        loadRestrictions();
-    }
-
-    private void loadRestrictions() {
         EventsBinding.RESTRICTIONS.post(new RestrictionsRegistrationEventJS());
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/EventsBinding.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/EventsBinding.java
@@ -6,5 +6,5 @@ import dev.latvian.mods.kubejs.event.EventHandler;
 public abstract class EventsBinding {
     public static final EventGroup GROUP = EventGroup.of("ItemSkillEvents");
 
-    public static final EventHandler RESTRICTIONS = GROUP.startup("register", () -> RestrictionsRegistrationEventJS.class);
+    public static final EventHandler RESTRICTIONS = GROUP.server("register", () -> RestrictionsRegistrationEventJS.class);
 }

--- a/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionJS.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionJS.java
@@ -2,22 +2,25 @@ package net.impleri.itemskills.integrations.kubejs.events;
 
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
 import dev.latvian.mods.rhino.util.HideFromJS;
+import net.impleri.itemskills.ItemHelper;
 import net.impleri.itemskills.restrictions.Restriction;
 import net.impleri.playerskills.restrictions.AbstractRestrictionBuilder;
 import net.impleri.playerskills.utils.SkillResourceLocation;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 public class RestrictionJS extends Restriction {
     private static final ResourceKey<Registry<Restriction>> key = ResourceKey.createRegistryKey(SkillResourceLocation.of("item_restriction_builders_registry"));
 
     public static final RegistryObjectBuilderTypes<Restriction> registry = RegistryObjectBuilderTypes.add(key, Restriction.class);
 
-    public RestrictionJS(Builder builder) {
+    public RestrictionJS(Item item, Builder builder) {
         super(
-                builder.id,
+                item,
                 builder.condition,
+                builder.replacement,
                 builder.producible,
                 builder.consumable,
                 builder.holdable,
@@ -29,6 +32,7 @@ public class RestrictionJS extends Restriction {
     }
 
     public static class Builder extends AbstractRestrictionBuilder<Restriction> {
+        public Item replacement;
 
         public boolean producible = true;
         public boolean consumable = true;
@@ -43,9 +47,15 @@ public class RestrictionJS extends Restriction {
             super(id);
         }
 
+        public Builder replaceWith(ResourceLocation replacement) {
+            this.replacement = ItemHelper.getItem(replacement);
+
+            return this;
+        }
+
         public Builder producible() {
             this.producible = true;
-            holdable = true;
+            this.holdable = true;
 
             return this;
         }
@@ -58,7 +68,7 @@ public class RestrictionJS extends Restriction {
 
         public Builder consumable() {
             this.consumable = true;
-            holdable = true;
+            this.holdable = true;
 
             return this;
         }
@@ -77,11 +87,11 @@ public class RestrictionJS extends Restriction {
 
         public Builder unholdable() {
             this.holdable = false;
-            producible = false;
-            consumable = false;
-            harmful = false;
-            wearable = false;
-            usable = false;
+            this.producible = false;
+            this.consumable = false;
+            this.harmful = false;
+            this.wearable = false;
+            this.usable = false;
 
             return this;
         }
@@ -100,7 +110,7 @@ public class RestrictionJS extends Restriction {
 
         public Builder harmful() {
             this.harmful = true;
-            holdable = true;
+            this.holdable = true;
 
             return this;
         }
@@ -113,7 +123,7 @@ public class RestrictionJS extends Restriction {
 
         public Builder wearable() {
             this.wearable = true;
-            holdable = true;
+            this.holdable = true;
 
             return this;
         }
@@ -126,7 +136,7 @@ public class RestrictionJS extends Restriction {
 
         public Builder usable() {
             this.usable = true;
-            holdable = true;
+            this.holdable = true;
 
             return this;
         }
@@ -138,25 +148,25 @@ public class RestrictionJS extends Restriction {
         }
 
         public Builder nothing() {
-            producible = true;
-            consumable = true;
-            holdable = true;
-            identifiable = true;
-            harmful = true;
-            wearable = true;
-            usable = true;
+            this.producible = true;
+            this.consumable = true;
+            this.holdable = true;
+            this.identifiable = true;
+            this.harmful = true;
+            this.wearable = true;
+            this.usable = true;
 
             return this;
         }
 
         public Builder everything() {
-            producible = false;
-            consumable = false;
-            holdable = false;
-            identifiable = false;
-            harmful = false;
-            wearable = false;
-            usable = false;
+            this.producible = false;
+            this.consumable = false;
+            this.holdable = false;
+            this.identifiable = false;
+            this.harmful = false;
+            this.wearable = false;
+            this.usable = false;
 
             return this;
         }
@@ -170,7 +180,12 @@ public class RestrictionJS extends Restriction {
         @HideFromJS
         @Override
         public Restriction createObject() {
-            return new RestrictionJS(this);
+            return null;
+        }
+
+        @HideFromJS
+        public Restriction createObject(Item item) {
+            return new RestrictionJS(item, this);
         }
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
@@ -2,6 +2,8 @@ package net.impleri.itemskills.integrations.kubejs.events;
 
 import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
+import net.impleri.itemskills.ItemHelper;
+import net.impleri.itemskills.ItemSkills;
 import net.impleri.itemskills.restrictions.Registry;
 import net.impleri.playerskills.utils.SkillResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -9,13 +11,19 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 public class RestrictionsRegistrationEventJS extends EventJS {
-    public void restrict(String item, @NotNull Consumer<RestrictionJS.Builder> consumer) {
-        var name = SkillResourceLocation.of(item);
+    public void restrict(String itemName, @NotNull Consumer<RestrictionJS.Builder> consumer) {
+        var name = SkillResourceLocation.of(itemName);
         var builder = new RestrictionJS.Builder(name);
 
         consumer.accept(builder);
 
-        var restriction = builder.createObject();
+        var item = ItemHelper.getItem(name);
+
+        if (ItemHelper.isEmptyItem(item)) {
+            ItemSkills.LOGGER.warn("Could not find any item named {}", name);
+        }
+
+        var restriction = builder.createObject(item);
         ConsoleJS.STARTUP.info("Created item restriction for " + item);
         Registry.INSTANCE.add(name, restriction);
     }

--- a/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
@@ -2,17 +2,30 @@ package net.impleri.itemskills.integrations.kubejs.events;
 
 import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import net.impleri.itemskills.ItemHelper;
-import net.impleri.itemskills.ItemSkills;
 import net.impleri.itemskills.restrictions.Registry;
 import net.impleri.playerskills.utils.SkillResourceLocation;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
 public class RestrictionsRegistrationEventJS extends EventJS {
     public void restrict(String itemName, @NotNull Consumer<RestrictionJS.Builder> consumer) {
+        if (itemName.trim().endsWith(":*")) {
+            var namespace = itemName.substring(0, itemName.indexOf(":"));
+
+            restrictNamespace(namespace, consumer);
+            return;
+        }
+
         var name = SkillResourceLocation.of(itemName);
+        restrictItem(name, consumer);
+    }
+
+    @HideFromJS
+    private void restrictItem(ResourceLocation name, @NotNull Consumer<RestrictionJS.Builder> consumer) {
         var builder = new RestrictionJS.Builder(name);
 
         consumer.accept(builder);
@@ -20,11 +33,19 @@ public class RestrictionsRegistrationEventJS extends EventJS {
         var item = ItemHelper.getItem(name);
 
         if (ItemHelper.isEmptyItem(item)) {
-            ItemSkills.LOGGER.warn("Could not find any item named {}", name);
+            ConsoleJS.SERVER.warn("Could not find any item named " + name.toString());
         }
 
         var restriction = builder.createObject(item);
-        ConsoleJS.STARTUP.info("Created item restriction for " + item);
+        ConsoleJS.SERVER.info("Created item restriction for " + item);
         Registry.INSTANCE.add(name, restriction);
+    }
+
+    @HideFromJS
+    private void restrictNamespace(String namespace, @NotNull Consumer<RestrictionJS.Builder> consumer) {
+        net.minecraft.core.Registry.ITEM.keySet()
+                .stream()
+                .filter(itemName -> itemName.getNamespace().equals(namespace))
+                .forEach(itemName -> restrictItem(itemName, consumer));
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/integrations/rei/BasicSkillsFiltering.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/rei/BasicSkillsFiltering.java
@@ -6,8 +6,7 @@ import net.impleri.itemskills.ItemSkills;
 import net.impleri.itemskills.client.ClientApi;
 import net.impleri.itemskills.utils.ListDiff;
 import net.impleri.playerskills.client.events.ClientSkillsUpdatedEvent;
-import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
 public class BasicSkillsFiltering {
     private static BasicFilteringRule.MarkDirty filteringRule;
 
-    private static final List<ResourceLocation> currentlyFiltered = new ArrayList<>();
+    private static final List<Item> currentlyFiltered = new ArrayList<>();
 
     public static void updateHidden(ClientSkillsUpdatedEvent event) {
         ItemSkills.LOGGER.debug("Client skills list has been updated: {}", event.next());
@@ -46,7 +45,7 @@ public class BasicSkillsFiltering {
 
     public static void register(BasicFilteringRule<?> rule) {
         filteringRule = rule.hide(() -> ClientApi.INSTANCE.getHidden().stream()
-                .map(item -> EntryStacks.of(Registry.ITEM.get(item)).cast())
+                .map(item -> EntryStacks.of(item).cast())
                 .collect(Collectors.toList()));
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/integrations/rei/SkillsDisplayVisibility.java
+++ b/common/src/main/java/net/impleri/itemskills/integrations/rei/SkillsDisplayVisibility.java
@@ -41,13 +41,13 @@ public class SkillsDisplayVisibility implements DisplayVisibilityPredicate {
      * Checks every ingredient to see if any are uncraftable
      */
     private boolean hasHiddenOutput(EntryStack<?> entry) {
-        return !ClientApi.INSTANCE.isProducible(entry.getIdentifier());
+        return !ClientApi.INSTANCE.isProducible(entry.castValue());
     }
 
     /**
      * Checks every ingredient to see if any are supposed to be hidden
      */
     private boolean hasHiddenInput(EntryStack<?> entry) {
-        return !ClientApi.INSTANCE.isConsumable(entry.getIdentifier());
+        return !ClientApi.INSTANCE.isConsumable(entry.castValue());
     }
 }

--- a/common/src/main/java/net/impleri/itemskills/mixins/MixinRecipeManager.java
+++ b/common/src/main/java/net/impleri/itemskills/mixins/MixinRecipeManager.java
@@ -1,7 +1,6 @@
 package net.impleri.itemskills.mixins;
 
 import com.mojang.datafixers.util.Pair;
-import net.impleri.itemskills.ItemHelper;
 import net.impleri.itemskills.ItemSkills;
 import net.impleri.itemskills.client.ClientApi;
 import net.minecraft.resources.ResourceLocation;
@@ -19,10 +18,10 @@ import java.util.Optional;
 
 @Mixin(RecipeManager.class)
 public class MixinRecipeManager {
-    private boolean isCraftable(Recipe<?> recipe) {
+    private boolean isProducible(Recipe<?> recipe) {
         var item = recipe.getResultItem().getItem();
-        ItemSkills.LOGGER.info("Checking if {} is craftable", item);
-        return ClientApi.INSTANCE.isProducible(ItemHelper.getItemKey(item));
+        ItemSkills.LOGGER.info("Checking if {} is producible", item);
+        return ClientApi.INSTANCE.isProducible(item);
     }
 
     @Inject(method = "getRecipeFor(Lnet/minecraft/world/item/crafting/RecipeType;Lnet/minecraft/world/Container;Lnet/minecraft/world/level/Level;)Ljava/util/Optional;", at = @At(value = "RETURN"), cancellable = true)
@@ -32,7 +31,7 @@ public class MixinRecipeManager {
             return;
         }
 
-        if (!isCraftable(value.get())) {
+        if (!isProducible(value.get())) {
             cir.setReturnValue(Optional.empty());
         }
     }
@@ -44,7 +43,7 @@ public class MixinRecipeManager {
             return;
         }
 
-        if (!isCraftable(value.get().getSecond())) {
+        if (!isProducible(value.get().getSecond())) {
             cir.setReturnValue(Optional.empty());
         }
     }
@@ -56,7 +55,7 @@ public class MixinRecipeManager {
             return;
         }
 
-        if (!isCraftable(value.get())) {
+        if (!isProducible(value.get())) {
             cir.setReturnValue(Optional.empty());
         }
     }

--- a/common/src/main/java/net/impleri/itemskills/restrictions/Restriction.java
+++ b/common/src/main/java/net/impleri/itemskills/restrictions/Restriction.java
@@ -1,13 +1,13 @@
 package net.impleri.itemskills.restrictions;
 
 import net.impleri.playerskills.restrictions.AbstractRestriction;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Predicate;
 
-public class Restriction extends AbstractRestriction<ResourceLocation> {
+public class Restriction extends AbstractRestriction<Item> {
     public final boolean producible;
     public final boolean consumable;
     public final boolean holdable;
@@ -17,8 +17,9 @@ public class Restriction extends AbstractRestriction<ResourceLocation> {
     public final boolean usable;
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable,
             @Nullable Boolean holdable,
@@ -27,7 +28,7 @@ public class Restriction extends AbstractRestriction<ResourceLocation> {
             @Nullable Boolean wearable,
             @Nullable Boolean usable
     ) {
-        super(item, condition);
+        super(item, condition, replacement);
         this.producible = Boolean.TRUE.equals(producible);
         this.consumable = Boolean.TRUE.equals(consumable);
         this.holdable = Boolean.TRUE.equals(holdable);
@@ -38,8 +39,9 @@ public class Restriction extends AbstractRestriction<ResourceLocation> {
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable,
             @Nullable Boolean holdable,
@@ -47,61 +49,74 @@ public class Restriction extends AbstractRestriction<ResourceLocation> {
             @Nullable Boolean harmful,
             @Nullable Boolean wearable
     ) {
-        this(item, condition, producible, consumable, holdable, identifiable, harmful, wearable, null);
+        this(item, condition, replacement, producible, consumable, holdable, identifiable, harmful, wearable, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable,
             @Nullable Boolean holdable,
             @Nullable Boolean identifiable,
             @Nullable Boolean harmful
     ) {
-        this(item, condition, producible, consumable, holdable, identifiable, harmful, null);
+        this(item, condition, replacement, producible, consumable, holdable, identifiable, harmful, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable,
             @Nullable Boolean holdable,
             @Nullable Boolean identifiable
     ) {
-        this(item, condition, producible, consumable, holdable, identifiable, null);
+        this(item, condition, replacement, producible, consumable, holdable, identifiable, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable,
             @Nullable Boolean holdable
     ) {
-        this(item, condition, producible, consumable, holdable, null);
+        this(item, condition, replacement, producible, consumable, holdable, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible,
             @Nullable Boolean consumable
     ) {
-        this(item, condition, producible, consumable, null);
+        this(item, condition, replacement, producible, consumable, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
             Predicate<Player> condition,
+            @Nullable Item replacement,
             @Nullable Boolean producible
     ) {
-        this(item, condition, producible, null);
+        this(item, condition, replacement, producible, null);
     }
 
     public Restriction(
-            ResourceLocation item,
+            Item item,
+            Predicate<Player> condition,
+            @Nullable Item replacement
+    ) {
+        this(item, condition, replacement, null);
+    }
+
+    public Restriction(
+            Item item,
             Predicate<Player> condition
     ) {
         this(item, condition, null);

--- a/common/src/main/java/net/impleri/itemskills/utils/ListDiff.java
+++ b/common/src/main/java/net/impleri/itemskills/utils/ListDiff.java
@@ -1,28 +1,27 @@
 package net.impleri.itemskills.utils;
 
-import net.minecraft.resources.ResourceLocation;
+import net.impleri.itemskills.ItemHelper;
+import net.minecraft.world.item.Item;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ListDiff {
-    public static boolean contains(List<ResourceLocation> a, List<ResourceLocation> b) {
+    public static boolean contains(List<Item> a, List<Item> b) {
         return getMissing(a, b).size() == 0;
     }
 
-    public static List<ResourceLocation> getMissing(List<ResourceLocation> a, List<ResourceLocation> b) {
+    public static List<Item> getMissing(List<Item> a, List<Item> b) {
         if (a.size() == 0 && b.size() == 0) {
             return new ArrayList<>();
         }
 
         var bStrings = b.stream()
-                .map(ResourceLocation::toString)
+                .map(ItemHelper::getItemKey)
                 .toList();
 
-        var aCopy = a.stream()
-                .filter(existing -> !bStrings.contains(existing.toString()))
+        return a.stream()
+                .filter(existing -> !bStrings.contains(ItemHelper.getItemKey(existing)))
                 .toList();
-
-        return aCopy;
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,9 +34,9 @@
   ],
   "depends": {
     "fabric": "*",
-    "minecraft": ">=1.19.2",
+    "minecraft": "1.19.2",
     "architectury": ">=6.2.43",
-    "playerskills": ">=1.0.0"
+    "playerskills": ">=1.5.1"
   },
   "recommends": {
     "kubejs": ""

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     modImplementation "me.shedaniel:RoughlyEnoughItems-forge:${rootProject.rei_version}"
     modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-forge:${rootProject.rei_version}"
 
+
     modCompileOnly "mezz.jei:jei-${rootProject.minecraft_version}-forge-api:${rootProject.jei_version}"
     modRuntimeOnly "mezz.jei:jei-${rootProject.minecraft_version}-forge:${rootProject.jei_version}"
 

--- a/forge/src/main/java/net/impleri/itemskills/integrations/jei/forge/ItemSkillsJeiForgePlugin.java
+++ b/forge/src/main/java/net/impleri/itemskills/integrations/jei/forge/ItemSkillsJeiForgePlugin.java
@@ -1,8 +1,10 @@
 package net.impleri.itemskills.integrations.jei.forge;
 
+import me.shedaniel.rei.plugincompatibilities.api.REIPluginCompatIgnore;
 import mezz.jei.api.JeiPlugin;
 import net.impleri.itemskills.integrations.jei.ItemSkillsJeiPlugin;
 
+@REIPluginCompatIgnore()
 @JeiPlugin()
 public class ItemSkillsJeiForgePlugin extends ItemSkillsJeiPlugin {
 }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -30,7 +30,7 @@ side = "BOTH"
 [[dependencies.itemskills]]
 modId = "playerskills"
 mandatory = true
-versionRange = "[1,)"
+versionRange = "[1.5.1,)"
 ordering = "NONE"
 side = "BOTH"
 
@@ -44,7 +44,7 @@ side = "BOTH"
 [[dependencies.itemskills]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.19.2,)"
+versionRange = "[1.19.2]"
 ordering = "NONE"
 side = "BOTH"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ forge_version=1.19.2-43.2.0
 kubejs_version=1902.6.0-build.142
 rhino_version=1902.2.2-build.264
 # PlayerSkills dependency
-playerskills_version=1.4.0
+playerskills_version=1.5.1
 # REI Integration
 rei_version=9.1.587
 #JEI Integration

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ are set, so be sure to set actual restrictions.
 
 ```js
 ItemSkillEvents.register(event => {
+  // Vanilla items cannot be used at all unless player is at stage 2 (or later)
+  event.restrict('minecraft:*', restrict => {
+    restrict.everything()
+      .if(player => player.cannot('skills:stage', 2));
+  });
+
   // Bed item cannot be used at all unless player is at stage 2 (or later)
   event.restrict('minecraft:bed', restrict => {
     restrict.everything()

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,11 @@ ItemSkillEvents.register(event => {
 });
 ```
 
+### Caveats
+
+JEI integration does not remove recipes related to the `unconsumable` flag. It does hide the recipes from right-clicking
+on the ingredient. However, it does not remove the recipe itself -- only `unconsumable` does that.
+
 ## Modpacks
 
 Want to use this in a modpack? Great! This was designed with modpack developers in mind. No need to ask.


### PR DESCRIPTION
FEATURES
Allows restrictions to target entire mods using the `modid:*` syntax (e.g. `minecraft:*` would restrict all vanilla items).

FIXES
Stops REI Compatibilities on Forge from loading the JEI plugin (we have our own REI plugin already)

BREAKING CHANGES
Item Skills Registration is moved to `server` (vs `startup`) so as to ensure items are registered.

Closes #7 