### PR TITLE
Reduce how often the inventory check runs to once per second

### DIFF
--- a/common/src/main/java/net/impleri/itemskills/ItemEvents.java
+++ b/common/src/main/java/net/impleri/itemskills/ItemEvents.java
@@ -3,7 +3,13 @@ package net.impleri.itemskills;
 import com.mojang.brigadier.CommandDispatcher;
 import dev.architectury.event.CompoundEventResult;
 import dev.architectury.event.EventResult;
-import dev.architectury.event.events.common.*;
+import dev.architectury.event.events.common.BlockEvent;
+import dev.architectury.event.events.common.CommandRegistrationEvent;
+import dev.architectury.event.events.common.EntityEvent;
+import dev.architectury.event.events.common.InteractionEvent;
+import dev.architectury.event.events.common.LifecycleEvent;
+import dev.architectury.event.events.common.PlayerEvent;
+import dev.architectury.event.events.common.TickEvent;
 import dev.architectury.platform.Platform;
 import dev.architectury.utils.value.IntValue;
 import net.impleri.itemskills.restrictions.Restrictions;
@@ -30,6 +36,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 class ItemEvents {
+    private static final int TICK_DELAY = 20; // 1/second
+
     public void registerEventHandlers() {
         LifecycleEvent.SERVER_STARTING.register(this::onStartup);
         TickEvent.PLAYER_POST.register(this::onPlayerTick);
@@ -61,6 +69,13 @@ class ItemEvents {
 
     private void onPlayerTick(Player player) {
         if (player.getLevel().isClientSide) {
+            return;
+        }
+
+        var server = player.getServer();
+
+        // Only run this once per tick delay
+        if (server != null && server.getTickCount() % TICK_DELAY != 0) {
             return;
         }
 


### PR DESCRIPTION
This reduces the likelihood of a skill update clearing out item replacements on the same tick as the inventory check which causes the inventory check to fail because two writes to the replacement cache collide. It can still happen, but it's now rarer. Would be great to introduce some concurrency in the cache to prevent this completely.